### PR TITLE
[codex] add optional cloudflare presenter sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+        env:
+          VITE_PRESENTATION_SYNC_MODE: ${{ vars.VITE_PRESENTATION_SYNC_MODE }}
+          VITE_PRESENTATION_SYNC_URL: ${{ vars.VITE_PRESENTATION_SYNC_URL }}
       - uses: actions/upload-pages-artifact@v3
         with:
           path: dist

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules
 dist
 dist-ssr
 *.local
+.wrangler/
+.dev.vars*
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -15,6 +15,55 @@ This is a K8s course website designed to help learners understand Kubernetes and
 1. 執行 `npm install` 安裝依賴
 2. 執行 `npm run dev` 啟動開發伺服器
 
+## Optional Cross-browser Presenter Sync
+
+The default GitHub Pages deployment still uses same-browser sync.
+
+If you want cross-browser presenter sync, deploy the optional Cloudflare Workers + Durable Objects module in `cloudflare/presenter-sync/` and configure:
+
+- `VITE_PRESENTATION_SYNC_MODE=auto`
+- `VITE_PRESENTATION_SYNC_URL=https://<your-worker-domain>/websocket`
+
+When those variables are missing or the realtime endpoint is unavailable, the app automatically falls back to same-browser sync.
+
+### What this enables
+
+- Presenter and audience can sync across different browsers and devices.
+- Presenter mode still opens one controller audience window as before.
+- When cross-browser sync is active, presenter mode also shows a `Copy audience URL` action for sharing a read-only audience link with other browsers.
+
+### Recommended rollout order
+
+1. Deploy the optional Cloudflare worker first.
+2. Verify the worker locally or on its public URL.
+3. Add GitHub Actions repository variables:
+   - `VITE_PRESENTATION_SYNC_MODE=auto`
+   - `VITE_PRESENTATION_SYNC_URL=https://<your-worker-domain>/websocket`
+4. Re-run the GitHub Pages workflow.
+
+This order avoids deploying a frontend that points to a realtime endpoint that does not exist yet.
+
+### GitHub Pages build-time variables
+
+GitHub Pages does not read runtime environment variables for a Vite app. The values are injected during the GitHub Actions build defined in `.github/workflows/deploy.yml`.
+
+After changing repository variables, trigger a new workflow run from the Actions tab or push a new commit.
+
+### Security notes
+
+- The copied audience URL is read-only. It does not include the presenter control token.
+- The controller audience window opened by presenter mode uses a separate URL with a control token. Do not share that URL.
+- If you deploy the Cloudflare worker, configure `ALLOWED_ORIGINS` so arbitrary sites cannot open browser WebSocket sessions against your relay.
+- This realtime feature is intentionally lightweight. It is suitable for course delivery and demos, not for hostile public environments without additional authentication and abuse protection.
+
+### Manual validation
+
+1. Start presenter mode on the admin page.
+2. Confirm the status shows cross-browser sync instead of same-browser fallback.
+3. Use `Copy audience URL` and open the copied link in a different browser.
+4. Confirm the shared audience follows presenter navigation but does not control the presenter.
+5. Confirm the controller audience window can still navigate presenter slides when its URL includes the control token.
+
 ## 專案結構 / Project Structure
 - `src/` - 應用程式源代碼
 - `public/` - 靜態資源

--- a/cloudflare/presenter-sync/README.md
+++ b/cloudflare/presenter-sync/README.md
@@ -1,0 +1,103 @@
+# Optional Cloudflare presenter sync
+
+This module adds an optional Cloudflare Workers + Durable Objects relay for cross-browser presenter sync.
+
+It is intentionally isolated from the main GitHub Pages app:
+
+- The main site still works without Cloudflare.
+- If you do not deploy this worker, the app falls back to same-browser sync.
+- This module only relays presentation messages and replays the latest presenter state to new connections.
+
+## Realtime behavior
+
+- A room is keyed by `session=<id>`.
+- WebSocket clients must connect with `role=presenter` or `role=audience`.
+- Controller audience clients also send `control=<token>`.
+- The relay keeps only the latest presenter `SYNC_STATE` in memory so a newly connected audience can catch up quickly.
+
+This worker is intentionally minimal. It does not store course content or maintain long-term session history.
+
+## Local development
+
+1. Install worker dependencies:
+
+   ```bash
+   cd cloudflare/presenter-sync
+   npm install
+   ```
+
+2. Run the worker locally:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Optional: restrict browser origins with an allowlist:
+
+   ```bash
+   ALLOWED_ORIGINS=http://localhost:5173,https://<your-github-pages-domain>
+   ```
+
+4. Start the frontend with the worker URL:
+
+   ```bash
+   VITE_PRESENTATION_SYNC_MODE=auto \
+   VITE_PRESENTATION_SYNC_URL=http://127.0.0.1:8787/websocket \
+   npm run dev
+   ```
+
+## Deploy
+
+1. Authenticate Wrangler with your Cloudflare account.
+2. Deploy the worker:
+
+   ```bash
+   cd cloudflare/presenter-sync
+   npm run deploy
+   ```
+
+3. Configure the static app with the deployed worker URL:
+
+   ```bash
+   VITE_PRESENTATION_SYNC_MODE=auto
+   VITE_PRESENTATION_SYNC_URL=https://<your-worker-domain>/websocket
+   ```
+
+4. Recommended: configure `ALLOWED_ORIGINS` in the Worker environment so only your course site can open browser WebSocket sessions.
+
+### Suggested Worker environment
+
+- `ALLOWED_ORIGINS=https://<your-github-pages-domain>`
+
+For local testing you can temporarily include `http://localhost:5173`.
+
+### Suggested GitHub repository variables
+
+- `VITE_PRESENTATION_SYNC_MODE=auto`
+- `VITE_PRESENTATION_SYNC_URL=https://<your-worker-domain>/websocket`
+
+The main GitHub Pages workflow already reads those values at build time.
+
+## Security model
+
+- Only presenter messages may send `HEARTBEAT` or `END_SESSION`.
+- Only audience messages may send `REQUEST_SYNC`.
+- Audience control messages are accepted only when the WebSocket connection itself was opened with a valid control token and the message token matches it.
+- Messages outside the freshness window are ignored to reduce replay risk.
+- Oversized payloads are rejected.
+- Rooms enforce a connection cap to limit abuse.
+
+This is still a lightweight relay. If you need stronger guarantees on the public internet, add explicit authentication, session expiration, and abuse-rate controls.
+
+## Deployment checklist
+
+1. Deploy the worker and confirm `GET /health` returns `ok`.
+2. Set `ALLOWED_ORIGINS`.
+3. Configure repository variables in GitHub.
+4. Run the GitHub Pages deployment workflow again.
+5. Verify presenter mode from one browser and a shared audience URL from another browser.
+
+## Endpoints
+
+- `GET /health` returns `ok`
+- `GET /websocket?session=<id>&role=<presenter|audience>[&control=<token>]` upgrades to a presenter-sync WebSocket room

--- a/cloudflare/presenter-sync/package.json
+++ b/cloudflare/presenter-sync/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@k8s-course-site/presenter-sync",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy"
+  },
+  "devDependencies": {
+    "wrangler": "^4.71.0"
+  }
+}

--- a/cloudflare/presenter-sync/src/index.ts
+++ b/cloudflare/presenter-sync/src/index.ts
@@ -1,0 +1,192 @@
+import { DurableObject } from 'cloudflare:workers'
+import { PresentationRoom } from './presentationRoom'
+import type { PresentationSenderRole } from '../../../src/types/presentation'
+
+export interface Env {
+  PRESENTATION_ROOM: DurableObjectNamespace<PresentationRoomDurableObject>
+  ALLOWED_ORIGINS?: string
+}
+
+interface ConnectionAttachment {
+  senderRole: PresentationSenderRole
+  controlToken: string | null
+}
+
+function isWebSocketUpgradeRequest(request: Request): boolean {
+  return request.method === 'GET' && request.headers.get('Upgrade')?.toLowerCase() === 'websocket'
+}
+
+function parseSessionId(request: Request): string | null {
+  const rawSessionId = new URL(request.url).searchParams.get('session')
+  if (!rawSessionId) {
+    return null
+  }
+
+  const sessionId = rawSessionId.trim()
+  if (!/^[A-Za-z0-9:_-]{1,128}$/.test(sessionId)) {
+    return null
+  }
+
+  return sessionId
+}
+
+function parseSenderRole(request: Request): PresentationSenderRole | null {
+  const role = new URL(request.url).searchParams.get('role')
+  if (role === 'presenter' || role === 'audience') {
+    return role
+  }
+
+  return null
+}
+
+function parseControlToken(request: Request): string | null {
+  const rawControlToken = new URL(request.url).searchParams.get('control')
+  if (!rawControlToken) {
+    return null
+  }
+
+  const controlToken = rawControlToken.trim()
+  if (!/^[A-Za-z0-9-]{1,128}$/.test(controlToken)) {
+    return null
+  }
+
+  return controlToken
+}
+
+function parseAllowedOrigins(env: Env): Set<string> {
+  if (!env.ALLOWED_ORIGINS) {
+    return new Set()
+  }
+
+  return new Set(
+    env.ALLOWED_ORIGINS
+      .split(',')
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0),
+  )
+}
+
+function isAllowedOrigin(request: Request, allowedOrigins: Set<string>): boolean {
+  if (allowedOrigins.size === 0) {
+    return true
+  }
+
+  const origin = request.headers.get('Origin')
+  if (!origin) {
+    return false
+  }
+
+  return allowedOrigins.has(origin)
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url)
+    const allowedOrigins = parseAllowedOrigins(env)
+
+    if (url.pathname === '/health') {
+      return new Response('ok', { status: 200 })
+    }
+
+    if (url.pathname !== '/websocket') {
+      return new Response('Use /websocket?session=<id> for presenter sync.', { status: 404 })
+    }
+
+    if (!isWebSocketUpgradeRequest(request)) {
+      return new Response('Expected Upgrade: websocket', { status: 426 })
+    }
+
+    if (!isAllowedOrigin(request, allowedOrigins)) {
+      return new Response('Origin not allowed.', { status: 403 })
+    }
+
+    const sessionId = parseSessionId(request)
+    if (!sessionId) {
+      return new Response('Missing or invalid session id.', { status: 400 })
+    }
+
+    const senderRole = parseSenderRole(request)
+    if (!senderRole) {
+      return new Response('Missing or invalid sender role.', { status: 400 })
+    }
+
+    const roomId = env.PRESENTATION_ROOM.idFromName(sessionId)
+    return env.PRESENTATION_ROOM.get(roomId).fetch(request)
+  },
+} satisfies ExportedHandler<Env>
+
+export class PresentationRoomDurableObject extends DurableObject<Env> {
+  private readonly room = new PresentationRoom()
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env)
+
+    for (const socket of this.ctx.getWebSockets()) {
+      const attachment = socket.deserializeAttachment() as ConnectionAttachment | null
+      if (!attachment || (attachment.senderRole !== 'presenter' && attachment.senderRole !== 'audience')) {
+        socket.close(1008, 'Invalid session metadata')
+        continue
+      }
+
+      this.room.restorePeer(socket, attachment)
+    }
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    if (!isWebSocketUpgradeRequest(request)) {
+      return new Response('Expected Upgrade: websocket', { status: 426 })
+    }
+
+    if (!this.room.canAcceptPeer()) {
+      return new Response('Presentation room is full.', { status: 429 })
+    }
+
+    const senderRole = parseSenderRole(request)
+    if (!senderRole) {
+      return new Response('Missing or invalid sender role.', { status: 400 })
+    }
+
+    const controlToken = parseControlToken(request)
+    if (senderRole === 'audience' && new URL(request.url).searchParams.has('control') && !controlToken) {
+      return new Response('Invalid control token.', { status: 400 })
+    }
+
+    const webSocketPair = new WebSocketPair()
+    const [client, server] = Object.values(webSocketPair)
+
+    this.ctx.acceptWebSocket(server)
+    server.serializeAttachment({
+      senderRole,
+      controlToken,
+    } satisfies ConnectionAttachment)
+    this.room.addPeer(server, { senderRole, controlToken })
+
+    return new Response(null, {
+      status: 101,
+      webSocket: client,
+    })
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message !== 'string') {
+      console.warn('Ignoring non-text presentation sync payload.')
+      return
+    }
+
+    const accepted = this.room.handleMessage(ws, message)
+    if (!accepted) {
+      console.warn('Ignoring invalid presentation sync payload.')
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    this.room.removePeer(ws)
+    ws.close(code, reason)
+  }
+
+  async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+    console.error('Presentation room websocket error.', error)
+    this.room.removePeer(ws)
+    ws.close(1011, 'WebSocket error')
+  }
+}

--- a/cloudflare/presenter-sync/src/presentationRoom.test.ts
+++ b/cloudflare/presenter-sync/src/presentationRoom.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { createPresentationMessage } from '../../../src/types/presentation'
+import { PresentationRoom } from './presentationRoom'
+
+function createPeer() {
+  const sent: string[] = []
+  return {
+    peer: {
+      send(message: string) {
+        sent.push(message)
+      },
+    },
+    sent,
+  }
+}
+
+function presenterMeta() {
+  return {
+    senderRole: 'presenter' as const,
+    controlToken: null,
+  }
+}
+
+function audienceMeta(controlToken: string | null = null) {
+  return {
+    senderRole: 'audience' as const,
+    controlToken,
+  }
+}
+
+describe('PresentationRoom', () => {
+  it('broadcasts valid messages to other peers and replays the latest presenter state to new peers', () => {
+    const room = new PresentationRoom()
+    const presenter = createPeer()
+    const audience = createPeer()
+    const lateJoiner = createPeer()
+
+    room.addPeer(presenter.peer, presenterMeta())
+    room.addPeer(audience.peer, audienceMeta())
+
+    const syncState = JSON.stringify(
+      createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 4, 'presenter'),
+    )
+
+    expect(room.handleMessage(presenter.peer, syncState)).toBe(true)
+    expect(presenter.sent).toEqual([])
+    expect(audience.sent).toEqual([syncState])
+
+    room.addPeer(lateJoiner.peer, audienceMeta())
+    expect(lateJoiner.sent).toEqual([syncState])
+  })
+
+  it('ignores invalid messages without broadcasting them', () => {
+    const room = new PresentationRoom()
+    const sender = createPeer()
+    const receiver = createPeer()
+
+    room.addPeer(sender.peer, audienceMeta())
+    room.addPeer(receiver.peer, audienceMeta())
+
+    expect(room.handleMessage(sender.peer, '{"invalid":true}')).toBe(false)
+    expect(receiver.sent).toEqual([])
+  })
+
+  it('rejects oversized payloads and sender-role mismatches', () => {
+    const room = new PresentationRoom()
+    const sender = createPeer()
+    const receiver = createPeer()
+
+    room.addPeer(sender.peer, audienceMeta())
+    room.addPeer(receiver.peer, audienceMeta())
+
+    const invalidAudienceEndSession = JSON.stringify(
+      createPresentationMessage('END_SESSION', 'demo-session', 'lesson1-morning', 0, 'audience'),
+    )
+
+    expect(room.handleMessage(sender.peer, invalidAudienceEndSession)).toBe(false)
+    expect(receiver.sent).toEqual([])
+
+    const oversizedPayload = 'x'.repeat(PresentationRoom.MAX_MESSAGE_BYTES + 1)
+    expect(room.handleMessage(sender.peer, oversizedPayload)).toBe(false)
+  })
+
+  it('enforces the room peer limit', () => {
+    const room = new PresentationRoom()
+
+    for (let index = 0; index < PresentationRoom.MAX_PEERS; index += 1) {
+      expect(room.addPeer(createPeer().peer, audienceMeta())).toBe(true)
+    }
+
+    expect(room.canAcceptPeer()).toBe(false)
+    expect(room.addPeer(createPeer().peer, audienceMeta())).toBe(false)
+  })
+
+  it('rejects controller sync from read-only audience connections', () => {
+    const room = new PresentationRoom()
+    const readOnlyAudience = createPeer()
+    const receiver = createPeer()
+
+    room.addPeer(readOnlyAudience.peer, audienceMeta())
+    room.addPeer(receiver.peer, presenterMeta())
+
+    const spoofedControlMessage = JSON.stringify(
+      createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 2, 'audience', {
+        controlToken: 'stolen-control-token',
+      }),
+    )
+
+    expect(room.handleMessage(readOnlyAudience.peer, spoofedControlMessage)).toBe(false)
+    expect(receiver.sent).toEqual([])
+  })
+})

--- a/cloudflare/presenter-sync/src/presentationRoom.ts
+++ b/cloudflare/presenter-sync/src/presentationRoom.ts
@@ -1,0 +1,92 @@
+import {
+  isAllowedPresentationMessageForSender,
+  isFreshPresentationMessage,
+  isPresentationSyncMessage,
+  type PresentationSenderRole,
+} from '../../../src/types/presentation'
+
+export interface PresentationRoomPeer {
+  send: (message: string) => void
+}
+
+export interface PresentationRoomPeerMetadata {
+  senderRole: PresentationSenderRole
+  controlToken: string | null
+}
+
+export class PresentationRoom {
+  static readonly MAX_MESSAGE_BYTES = 8_192
+  static readonly MAX_PEERS = 32
+  private readonly peers = new Map<PresentationRoomPeer, PresentationRoomPeerMetadata>()
+  private lastPresenterState: string | null = null
+
+  restorePeer(peer: PresentationRoomPeer, metadata: PresentationRoomPeerMetadata): void {
+    this.peers.set(peer, metadata)
+  }
+
+  canAcceptPeer(): boolean {
+    return this.peers.size < PresentationRoom.MAX_PEERS
+  }
+
+  addPeer(peer: PresentationRoomPeer, metadata: PresentationRoomPeerMetadata): boolean {
+    if (!this.canAcceptPeer()) {
+      return false
+    }
+
+    this.peers.set(peer, metadata)
+
+    if (this.lastPresenterState) {
+      peer.send(this.lastPresenterState)
+    }
+
+    return true
+  }
+
+  removePeer(peer: PresentationRoomPeer): void {
+    this.peers.delete(peer)
+  }
+
+  handleMessage(sender: PresentationRoomPeer, rawMessage: string): boolean {
+    if (new TextEncoder().encode(rawMessage).byteLength > PresentationRoom.MAX_MESSAGE_BYTES) {
+      return false
+    }
+
+    try {
+      const payload: unknown = JSON.parse(rawMessage)
+      if (!isPresentationSyncMessage(payload) || !isAllowedPresentationMessageForSender(payload)) {
+        return false
+      }
+
+      if (!isFreshPresentationMessage(payload)) {
+        return false
+      }
+
+      const senderMetadata = this.peers.get(sender)
+      if (!senderMetadata || payload.senderRole !== senderMetadata.senderRole) {
+        return false
+      }
+
+      if (
+        payload.senderRole === 'audience' &&
+        payload.type === 'SYNC_STATE' &&
+        (!senderMetadata.controlToken || payload.controlToken !== senderMetadata.controlToken)
+      ) {
+        return false
+      }
+
+      if (payload.type === 'SYNC_STATE' && payload.senderRole === 'presenter') {
+        this.lastPresenterState = rawMessage
+      }
+
+      for (const peer of this.peers.keys()) {
+        if (peer !== sender) {
+          peer.send(rawMessage)
+        }
+      }
+
+      return true
+    } catch {
+      return false
+    }
+  }
+}

--- a/cloudflare/presenter-sync/wrangler.jsonc
+++ b/cloudflare/presenter-sync/wrangler.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "k8s-course-site-presenter-sync",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-03-09",
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "PRESENTATION_ROOM",
+        "class_name": "PresentationRoomDurableObject"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_classes": [
+        "PresentationRoomDurableObject"
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,8 @@
         "tailwindcss": "^3.4.19",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.48.0",
-        "vite": "^7.3.1"
+        "vite": "^7.3.1",
+        "vitest": "^3.2.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1465,6 +1466,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1799,6 +1818,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1902,6 +2036,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
@@ -2028,6 +2172,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2069,6 +2223,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2084,6 +2255,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2221,6 +2402,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2248,6 +2439,13 @@
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2488,6 +2686,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2496,6 +2704,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3006,6 +3224,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3014,6 +3239,16 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/merge2": {
@@ -3237,6 +3472,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3699,6 +3951,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3708,6 +3967,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
@@ -3721,6 +3994,26 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -3832,6 +4125,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3847,6 +4154,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -4063,6 +4400,102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4077,6 +4510,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -28,6 +29,7 @@
     "tailwindcss": "^3.4.19",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.48.0",
+    "vitest": "^3.2.4",
     "vite": "^7.3.1"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,11 +4,19 @@ import type { Slide } from './slides/lesson1-morning/index'
 import AudienceView from './components/AudienceView'
 import { usePresentationChannel } from './hooks/usePresentationChannel'
 import {
+  canAudienceControlPresenter,
   createPresentationMessage,
+  isPresenterBroadcastMessage,
+  parseControlToken,
   parseSessionId,
   parseViewMode,
+  shouldAcceptAudienceControlMessage,
   type ViewMode,
 } from './types/presentation'
+import {
+  getPresentationSyncCapabilityLabel,
+  isPresentationTransportActive,
+} from './types/presentationTransport'
 
 // 課程列表
 const LESSONS = [
@@ -206,12 +214,58 @@ function createSessionId(): string {
   return `session-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`
 }
 
-function buildAudienceUrl(sessionId: string, lessonId: string): string {
+function buildAudienceUrl(sessionId: string, lessonId: string, controlToken?: string | null): string {
   const url = new URL(window.location.href)
   url.searchParams.set('view', 'audience')
   url.searchParams.set('session', sessionId)
+  if (controlToken) {
+    url.searchParams.set('control', controlToken)
+  } else {
+    url.searchParams.delete('control')
+  }
   url.hash = lessonId
   return url.toString()
+}
+
+function buildPresenterControlStorageKey(sessionId: string): string {
+  return `k8s-course-presenter-control:${sessionId}`
+}
+
+function readPresenterControlToken(sessionId: string | null): string | null {
+  if (!sessionId || typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    const token = window.sessionStorage.getItem(buildPresenterControlStorageKey(sessionId))
+    return token && token.trim().length > 0 ? token : null
+  } catch {
+    return null
+  }
+}
+
+function persistPresenterControlToken(sessionId: string, controlToken: string): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.sessionStorage.setItem(buildPresenterControlStorageKey(sessionId), controlToken)
+  } catch {
+    // Ignore storage failures and keep the URL token as fallback.
+  }
+}
+
+function clearPresenterControlToken(sessionId: string | null): void {
+  if (!sessionId || typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.sessionStorage.removeItem(buildPresenterControlStorageKey(sessionId))
+  } catch {
+    // Ignore storage failures on cleanup.
+  }
 }
 
 function isAdminPath(): boolean {
@@ -224,6 +278,20 @@ function App() {
   const [isAdmin] = useState(isAdminPath)
   const [viewMode, setViewMode] = useState<ViewMode>(() => parseViewMode(window.location.search))
   const [sessionId, setSessionId] = useState<string | null>(() => parseSessionId(window.location.search))
+  const [controlToken, setControlToken] = useState<string | null>(() => {
+    const urlControlToken = parseControlToken(window.location.search)
+    if (urlControlToken) {
+      return urlControlToken
+    }
+
+    const initialViewMode = parseViewMode(window.location.search)
+    const initialSessionId = parseSessionId(window.location.search)
+    if (initialViewMode === 'presenter') {
+      return readPresenterControlToken(initialSessionId)
+    }
+
+    return null
+  })
   const [currentLesson, setCurrentLesson] = useState(getLessonIndexFromHash)
   const [currentSlide, setCurrentSlide] = useState(0)
   const [showNotes, setShowNotes] = useState(false)
@@ -240,6 +308,7 @@ function App() {
   )
   const [presenterError, setPresenterError] = useState<string | null>(null)
   const [manualAudienceUrl, setManualAudienceUrl] = useState<string | null>(null)
+  const [copyAudienceUrlState, setCopyAudienceUrlState] = useState<'idle' | 'copied' | 'error'>('idle')
   const [sessionStartedAt, setSessionStartedAt] = useState<number | null>(null)
   const [clockTick, setClockTick] = useState(() => Date.now())
   const [timerPaused, setTimerPaused] = useState(false)
@@ -248,10 +317,15 @@ function App() {
   const pendingAudienceSlideRef = useRef<number | null>(null)
   const lastAudienceSignalAtRef = useRef<number | null>(null)
   const hasReceivedInitialSyncRef = useRef(false)
-  const audienceManualNavRef = useRef(false)
   const isAudienceView = viewMode === 'audience'
   const isPresenterModeEnabled = viewMode === 'presenter' && Boolean(sessionId)
-  const { latestMessage, transportStatus, sendMessage } = usePresentationChannel(sessionId)
+  const audienceControlsEnabled = canAudienceControlPresenter(viewMode, sessionId, controlToken)
+  const channelSenderRole = viewMode === 'presenter' ? 'presenter' : 'audience'
+  const { latestMessage, transportStatus, syncCapability, sendMessage } = usePresentationChannel(sessionId, {
+    senderRole: channelSenderRole,
+    controlToken: viewMode === 'audience' ? controlToken : null,
+  })
+  const isTransportReady = isPresentationTransportActive(transportStatus)
 
   // 切換課程（同步 URL hash）
   const switchLesson = useCallback((idx: number) => {
@@ -268,9 +342,11 @@ function App() {
     if (viewMode === 'presenter' && sessionId) {
       url.searchParams.set('view', 'presenter')
       url.searchParams.set('session', sessionId)
+      url.searchParams.delete('control')
     } else {
       url.searchParams.delete('view')
       url.searchParams.delete('session')
+      url.searchParams.delete('control')
     }
     window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`)
   }, [isAudienceView, sessionId, viewMode])
@@ -320,28 +396,45 @@ function App() {
   const prevSlide = useCallback(() => goToSlide(currentSlide - 1), [currentSlide, goToSlide])
 
   const audienceNav = useCallback((direction: 'next' | 'prev') => {
-    audienceManualNavRef.current = true
-    if (direction === 'next') {
-      goToSlide(currentSlide + 1)
-    } else {
-      goToSlide(currentSlide - 1)
+    if (!audienceControlsEnabled || !sessionId || !controlToken) {
+      return
     }
-  }, [currentSlide, goToSlide])
+
+    const nextIndex = direction === 'next' ? currentSlide + 1 : currentSlide - 1
+    if (nextIndex < 0 || nextIndex >= slides.length) {
+      return
+    }
+
+    goToSlide(nextIndex)
+    sendMessage(
+      createPresentationMessage('SYNC_STATE', sessionId, LESSONS[currentLesson].id, nextIndex, 'audience', {
+        controlToken,
+      }),
+    )
+  }, [audienceControlsEnabled, controlToken, currentLesson, currentSlide, goToSlide, sendMessage, sessionId, slides.length])
 
   const postPresentationMessage = useCallback(
-    (type: 'SYNC_STATE' | 'REQUEST_SYNC' | 'HEARTBEAT' | 'END_SESSION', lessonId: string, slideIndex: number): boolean => {
+    (
+      type: 'SYNC_STATE' | 'REQUEST_SYNC' | 'HEARTBEAT' | 'END_SESSION',
+      lessonId: string,
+      slideIndex: number,
+      senderRole: 'presenter' | 'audience',
+      options?: { controlToken?: string | null },
+    ): boolean => {
       if (!sessionId) {
         return false
       }
-      return sendMessage(createPresentationMessage(type, sessionId, lessonId, slideIndex))
+      return sendMessage(createPresentationMessage(type, sessionId, lessonId, slideIndex, senderRole, options))
     },
     [sendMessage, sessionId],
   )
 
   const startPresenterMode = useCallback(() => {
     const activeSessionId = sessionId ?? createSessionId()
+    const activeControlToken = createSessionId()
     const activeLessonId = LESSONS[currentLesson].id
-    const audienceUrl = buildAudienceUrl(activeSessionId, activeLessonId)
+    const audienceUrl = buildAudienceUrl(activeSessionId, activeLessonId, activeControlToken)
+    persistPresenterControlToken(activeSessionId, activeControlToken)
 
     const openedWindow = window.open(audienceUrl, `k8s-audience-${activeSessionId}`, 'popup=yes,width=1366,height=768')
     if (!openedWindow) {
@@ -349,6 +442,7 @@ function App() {
       setManualAudienceUrl(audienceUrl)
       setViewMode('presenter')
       setSessionId(activeSessionId)
+      setControlToken(activeControlToken)
       setPresenterSyncStatus('disconnected')
       return
     }
@@ -358,26 +452,69 @@ function App() {
     setManualAudienceUrl(null)
     setViewMode('presenter')
     setSessionId(activeSessionId)
+    setControlToken(activeControlToken)
     setSessionStartedAt(Date.now())
     setPresenterSyncStatus('connecting')
   }, [currentLesson, sessionId])
 
+  const reopenAudienceWindow = useCallback(() => {
+    if (!sessionId || !controlToken) {
+      startPresenterMode()
+      return
+    }
+
+    const lessonId = LESSONS[currentLesson].id
+    const audienceUrl = buildAudienceUrl(sessionId, lessonId, controlToken)
+    const openedWindow = window.open(audienceUrl, `k8s-audience-${sessionId}`, 'popup=yes,width=1366,height=768')
+
+    if (!openedWindow) {
+      setPresenterError('Popup blocked. Allow popups for this site and try again.')
+      setManualAudienceUrl(audienceUrl)
+      setPresenterSyncStatus('disconnected')
+      return
+    }
+
+    audienceWindowRef.current = openedWindow
+    setPresenterError(null)
+    setManualAudienceUrl(null)
+    setPresenterSyncStatus('connecting')
+    postPresentationMessage('SYNC_STATE', lessonId, currentSlide, 'presenter')
+  }, [controlToken, currentLesson, currentSlide, postPresentationMessage, sessionId, startPresenterMode])
+
   const stopPresenterMode = useCallback(() => {
     const lessonId = LESSONS[currentLesson].id
-    postPresentationMessage('END_SESSION', lessonId, currentSlide)
+    postPresentationMessage('END_SESSION', lessonId, currentSlide, 'presenter')
     if (audienceWindowRef.current && !audienceWindowRef.current.closed) {
       audienceWindowRef.current.close()
     }
     audienceWindowRef.current = null
+    clearPresenterControlToken(sessionId)
     setViewMode('single')
     setSessionId(null)
+    setControlToken(null)
     setSessionStartedAt(null)
     setTimerPaused(false)
     setPausedElapsed(0)
     setPresenterError(null)
     setManualAudienceUrl(null)
+    setCopyAudienceUrlState('idle')
     setPresenterSyncStatus('idle')
-  }, [currentLesson, currentSlide, postPresentationMessage])
+  }, [currentLesson, currentSlide, postPresentationMessage, sessionId])
+
+  const copyAudienceUrl = useCallback(async () => {
+    if (!sessionId) {
+      return
+    }
+
+    const audienceUrl = buildAudienceUrl(sessionId, LESSONS[currentLesson].id)
+
+    try {
+      await navigator.clipboard.writeText(audienceUrl)
+      setCopyAudienceUrlState('copied')
+    } catch {
+      setCopyAudienceUrlState('error')
+    }
+  }, [currentLesson, sessionId])
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -413,7 +550,7 @@ function App() {
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [audienceNav, isAudienceView, isPresenterModeEnabled, nextSlide, prevSlide, startPresenterMode, stopPresenterMode])
+  }, [audienceNav, isAdmin, isAudienceView, isPresenterModeEnabled, nextSlide, prevSlide, startPresenterMode, stopPresenterMode])
 
   const slide: Slide = slides[currentSlide] || slides[0]
   const lesson = LESSONS[currentLesson]
@@ -446,22 +583,31 @@ function App() {
       return
     }
 
-    if (isAudienceView && transportStatus === 'unsupported') {
+    if (isAudienceView && (transportStatus === 'unsupported' || transportStatus === 'error')) {
       setAudienceConnectionState('unsupported')
       return
     }
 
-    if (isAudienceView && !hasReceivedInitialSyncRef.current) {
+    if (isAudienceView && (!isTransportReady || !hasReceivedInitialSyncRef.current)) {
       setAudienceConnectionState('loading')
     }
-  }, [isAudienceView, sessionId, transportStatus])
+  }, [isAudienceView, isTransportReady, sessionId, transportStatus])
 
   useEffect(() => {
-    if (transportStatus !== 'ready') {
-      if (isPresenterModeEnabled && transportStatus === 'unsupported') {
+    if (!isTransportReady) {
+      if (isPresenterModeEnabled && transportStatus === 'connecting') {
         // eslint-disable-next-line react-hooks/set-state-in-effect
+        setPresenterSyncStatus('connecting')
+        setPresenterError(null)
+      }
+
+      if (isPresenterModeEnabled && (transportStatus === 'unsupported' || transportStatus === 'error')) {
         setPresenterSyncStatus('unsupported')
-        setPresenterError('BroadcastChannel is not supported in this browser.')
+        setPresenterError(
+          transportStatus === 'unsupported'
+            ? 'This browser cannot provide presenter sync in the selected mode.'
+            : 'Cross-browser sync could not connect. Check your sync setup and try again.',
+        )
       }
       return
     }
@@ -470,14 +616,37 @@ function App() {
       return
     }
 
-    if (isPresenterModeEnabled && latestMessage.type === 'REQUEST_SYNC') {
+    if (isPresenterModeEnabled && latestMessage.type === 'REQUEST_SYNC' && latestMessage.senderRole === 'audience') {
       setPresenterSyncStatus('connected')
       setPresenterError(null)
-      postPresentationMessage('SYNC_STATE', lesson.id, currentSlide)
+      postPresentationMessage('SYNC_STATE', lesson.id, currentSlide, 'presenter')
+      return
+    }
+
+    if (isPresenterModeEnabled && shouldAcceptAudienceControlMessage(latestMessage, controlToken)) {
+      const syncedLessonIndex = LESSONS.findIndex((item) => item.id === latestMessage.lessonId)
+      if (syncedLessonIndex === -1) {
+        return
+      }
+
+      setPresenterSyncStatus('connected')
+      setPresenterError(null)
+
+      if (syncedLessonIndex !== currentLesson) {
+        setCurrentLesson(syncedLessonIndex)
+        window.location.hash = latestMessage.lessonId
+        return
+      }
+
+      goToSlide(Math.min(Math.max(latestMessage.slideIndex, 0), Math.max(slides.length - 1, 0)))
       return
     }
 
     if (!isAudienceView) {
+      return
+    }
+
+    if (!isPresenterBroadcastMessage(latestMessage)) {
       return
     }
 
@@ -495,7 +664,7 @@ function App() {
       return
     }
 
-    if (latestMessage.type !== 'SYNC_STATE') {
+    if (latestMessage.type !== 'SYNC_STATE' || latestMessage.senderRole !== 'presenter') {
       return
     }
 
@@ -515,10 +684,9 @@ function App() {
       return
     }
 
-    if (!audienceManualNavRef.current) {
-      goToSlide(Math.min(Math.max(latestMessage.slideIndex, 0), Math.max(slides.length - 1, 0)))
-    }
+    goToSlide(Math.min(Math.max(latestMessage.slideIndex, 0), Math.max(slides.length - 1, 0)))
   }, [
+    controlToken,
     currentLesson,
     currentSlide,
     goToSlide,
@@ -528,42 +696,43 @@ function App() {
     lesson.id,
     postPresentationMessage,
     slides.length,
+    isTransportReady,
     transportStatus,
   ])
 
   useEffect(() => {
-    if (!isAudienceView || !sessionId || transportStatus !== 'ready') {
+    if (!isAudienceView || !sessionId || !isTransportReady) {
       return
     }
 
-    postPresentationMessage('REQUEST_SYNC', lesson.id, currentSlide)
+    postPresentationMessage('REQUEST_SYNC', lesson.id, 0, 'audience')
     const retryTimer = window.setInterval(() => {
       if (!hasReceivedInitialSyncRef.current) {
-        postPresentationMessage('REQUEST_SYNC', lesson.id, currentSlide)
+        postPresentationMessage('REQUEST_SYNC', lesson.id, 0, 'audience')
       }
     }, 2000)
 
     return () => window.clearInterval(retryTimer)
-  }, [currentSlide, isAudienceView, lesson.id, postPresentationMessage, sessionId, transportStatus])
+  }, [isAudienceView, isTransportReady, lesson.id, postPresentationMessage, sessionId])
 
   useEffect(() => {
-    if (!isPresenterModeEnabled || transportStatus !== 'ready') {
+    if (!isPresenterModeEnabled || !isTransportReady) {
       return
     }
-    postPresentationMessage('SYNC_STATE', lesson.id, currentSlide)
-  }, [currentSlide, isPresenterModeEnabled, lesson.id, postPresentationMessage, transportStatus])
+    postPresentationMessage('SYNC_STATE', lesson.id, currentSlide, 'presenter')
+  }, [currentSlide, isPresenterModeEnabled, isTransportReady, lesson.id, postPresentationMessage])
 
   useEffect(() => {
-    if (!isPresenterModeEnabled || transportStatus !== 'ready') {
+    if (!isPresenterModeEnabled || !isTransportReady) {
       return
     }
 
     const heartbeatTimer = window.setInterval(() => {
-      postPresentationMessage('HEARTBEAT', lesson.id, currentSlide)
+      postPresentationMessage('HEARTBEAT', lesson.id, currentSlide, 'presenter')
     }, 2000)
 
     return () => window.clearInterval(heartbeatTimer)
-  }, [currentSlide, isPresenterModeEnabled, lesson.id, postPresentationMessage, transportStatus])
+  }, [currentSlide, isPresenterModeEnabled, isTransportReady, lesson.id, postPresentationMessage])
 
   useEffect(() => {
     if (!isPresenterModeEnabled) {
@@ -626,6 +795,18 @@ function App() {
     }
   }, [isAudienceView, sessionId])
 
+  useEffect(() => {
+    if (copyAudienceUrlState === 'idle') {
+      return
+    }
+
+    const timer = window.setTimeout(() => {
+      setCopyAudienceUrlState('idle')
+    }, 2000)
+
+    return () => window.clearTimeout(timer)
+  }, [copyAudienceUrlState])
+
   // 解析所有投影片 notes 中的 Q&A
   const qaItems = useMemo(() => {
     const marker = '\u3010\u9810\u671f\u96e3\u641e\u5b78\u54e1\u554f\u984c'
@@ -669,9 +850,11 @@ function App() {
     : presenterSyncStatus === 'disconnected'
     ? 'Audience disconnected'
     : presenterSyncStatus === 'unsupported'
-    ? 'Browser unsupported'
+    ? 'Sync unavailable'
     : 'Presenter mode off'
-
+  const presenterTransportLabel = syncCapability === 'same-browser' && transportStatus === 'fallback'
+    ? 'Same-browser fallback'
+    : getPresentationSyncCapabilityLabel(syncCapability)
   if (isAudienceView) {
     return (
       <AudienceView
@@ -680,6 +863,7 @@ function App() {
         slide={slide || null}
         loading={loading}
         connectionState={audienceConnectionState}
+        controlsEnabled={audienceControlsEnabled}
         currentSlide={currentSlide}
         totalSlides={slides.length}
         onPrev={() => audienceNav('prev')}
@@ -1035,7 +1219,7 @@ function App() {
               </a>
             )}
             <button
-              onClick={startPresenterMode}
+              onClick={reopenAudienceWindow}
               className="mt-3 px-3 py-1.5 text-sm rounded bg-red-700 hover:bg-red-600 transition-colors"
             >
               Retry opening audience window
@@ -1130,33 +1314,6 @@ function App() {
                   </div>
                 </div>
 
-                <div className="bg-slate-900/70 border border-slate-700 rounded-xl p-4">
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="text-slate-400">Presenter timer</span>
-                    <div className="flex items-center gap-3">
-                      <span className={`font-semibold tabular-nums text-lg ${timerPaused ? 'text-amber-400' : 'text-slate-200'}`}>
-                        {elapsedMinutes}:{elapsedRemainderSeconds.toString().padStart(2, '0')}
-                      </span>
-                      <button
-                        onClick={toggleTimerPause}
-                        className={`px-3 py-1 rounded-lg text-sm font-medium transition-colors ${
-                          timerPaused
-                            ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
-                            : 'bg-amber-600 hover:bg-amber-500 text-white'
-                        }`}
-                        title={timerPaused ? '繼續計時' : '暫停計時'}
-                      >
-                        {timerPaused ? '▶ 繼續' : '⏸ 暫停'}
-                      </button>
-                    </div>
-                  </div>
-                  <div className="flex items-center justify-between mt-2 text-xs">
-                    <span className="text-slate-500">{presenterStatusLabel}</span>
-                    <span className="text-slate-500">
-                      {currentSlide + 1} / {slides.length}
-                    </span>
-                  </div>
-                </div>
               </div>
             </div>
           ) : (
@@ -1253,6 +1410,26 @@ function App() {
               <span className="text-slate-400 text-sm hidden md:block">{lesson.label}</span>
               <span className="text-slate-600 hidden md:block">·</span>
               <span className="text-slate-400 text-sm">{currentSlide + 1} / {slides.length}</span>
+              {isAdmin && isPresenterModeEnabled && (
+                <>
+                  <span className="text-slate-600 hidden md:block">·</span>
+                  <span className="text-slate-400 text-sm hidden md:block">Timer</span>
+                  <span className={`font-semibold tabular-nums text-sm ${timerPaused ? 'text-amber-400' : 'text-slate-200'}`}>
+                    {elapsedMinutes}:{elapsedRemainderSeconds.toString().padStart(2, '0')}
+                  </span>
+                  <button
+                    onClick={toggleTimerPause}
+                    className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
+                      timerPaused
+                        ? 'bg-emerald-600 hover:bg-emerald-500 text-white'
+                        : 'bg-amber-600 hover:bg-amber-500 text-white'
+                    }`}
+                    title={timerPaused ? '繼續計時' : '暫停計時'}
+                  >
+                    {timerPaused ? '▶ 繼續' : '⏸ 暫停'}
+                  </button>
+                </>
+              )}
               {isAdmin && !isPresenterModeEnabled && (
                 <button
                   onClick={() => setShowNotes(!showNotes)}
@@ -1283,15 +1460,55 @@ function App() {
                 </button>
               )}
               {isAdmin && isPresenterModeEnabled && (
-                <span className={`text-xs px-2 py-1 rounded border ${
-                  presenterSyncStatus === 'connected'
-                    ? 'text-emerald-300 border-emerald-700/70 bg-emerald-900/40'
-                    : presenterSyncStatus === 'unsupported'
-                    ? 'text-red-300 border-red-700/70 bg-red-900/40'
-                    : 'text-amber-300 border-amber-700/70 bg-amber-900/40'
-                }`}>
-                  {presenterStatusLabel}
-                </span>
+                <div className="flex items-center gap-2">
+                  <span className={`text-xs px-2 py-1 rounded border ${
+                    presenterSyncStatus === 'connected'
+                      ? 'text-emerald-300 border-emerald-700/70 bg-emerald-900/40'
+                      : presenterSyncStatus === 'unsupported'
+                      ? 'text-red-300 border-red-700/70 bg-red-900/40'
+                      : 'text-amber-300 border-amber-700/70 bg-amber-900/40'
+                  }`}>
+                    {presenterStatusLabel}
+                  </span>
+                  <span className={`text-xs px-2 py-1 rounded border ${
+                    syncCapability === 'cross-browser'
+                      ? 'text-sky-300 border-sky-700/70 bg-sky-900/40'
+                      : syncCapability === 'same-browser'
+                      ? 'text-slate-300 border-slate-700/70 bg-slate-900/40'
+                      : 'text-red-300 border-red-700/70 bg-red-900/40'
+                  }`}>
+                    {presenterTransportLabel}
+                  </span>
+                  {syncCapability === 'cross-browser' && (
+                    <button
+                      onClick={() => {
+                        void copyAudienceUrl()
+                      }}
+                      className={`px-3 py-1.5 rounded-lg text-xs border transition-colors ${
+                        copyAudienceUrlState === 'copied'
+                          ? 'border-emerald-700/70 bg-emerald-900/40 text-emerald-200'
+                          : copyAudienceUrlState === 'error'
+                          ? 'border-red-700/70 bg-red-900/40 text-red-200'
+                          : 'border-sky-700/70 bg-sky-900/40 text-sky-200 hover:bg-sky-800/50'
+                      }`}
+                      title="Copy a read-only audience URL for other browsers"
+                    >
+                      {copyAudienceUrlState === 'copied'
+                        ? 'Audience URL copied'
+                        : copyAudienceUrlState === 'error'
+                        ? 'Copy failed'
+                        : 'Copy audience URL'}
+                    </button>
+                  )}
+                  {presenterSyncStatus === 'disconnected' && (
+                    <button
+                      onClick={reopenAudienceWindow}
+                      className="px-3 py-1.5 rounded-lg text-xs border border-amber-700/70 bg-amber-900/40 text-amber-200 hover:bg-amber-800/50 transition-colors"
+                    >
+                      Reopen audience
+                    </button>
+                  )}
+                </div>
               )}
             </div>
 

--- a/src/components/AudienceView.tsx
+++ b/src/components/AudienceView.tsx
@@ -8,6 +8,7 @@ interface AudienceViewProps {
   slide: Slide | null
   loading: boolean
   connectionState: AudienceConnectionState
+  controlsEnabled: boolean
   currentSlide: number
   totalSlides: number
   onPrev: () => void
@@ -30,12 +31,40 @@ function getConnectionLabel(state: AudienceConnectionState): string {
   return 'Session missing'
 }
 
+function getAudienceStatusBadge(
+  connectionState: AudienceConnectionState,
+  controlsEnabled: boolean,
+): { label: string, className: string } | null {
+  if (connectionState === 'connected') {
+    if (!controlsEnabled) {
+      return {
+        label: 'Read-only',
+        className: 'bg-slate-900/80 text-slate-300 border-slate-700/80',
+      }
+    }
+    return null
+  }
+
+  if (connectionState === 'disconnected') {
+    return {
+      label: 'Disconnected',
+      className: 'bg-red-900/70 text-red-200 border-red-700/80',
+    }
+  }
+
+  return {
+    label: getConnectionLabel(connectionState),
+    className: 'bg-amber-900/70 text-amber-200 border-amber-700/80',
+  }
+}
+
 export default function AudienceView({
   lessonLabel,
   lessonTitle,
   slide,
   loading,
   connectionState,
+  controlsEnabled,
   currentSlide,
   totalSlides,
   onPrev,
@@ -43,24 +72,21 @@ export default function AudienceView({
 }: AudienceViewProps) {
   const showWaitingState = loading || connectionState === 'loading'
   const showError = connectionState === 'missing-session' || connectionState === 'unsupported'
+  const statusBadge = getAudienceStatusBadge(connectionState, controlsEnabled)
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 text-white">
-      <div className="fixed top-4 left-4 right-4 flex items-center justify-between z-20 pointer-events-none">
+      <div className="fixed top-4 left-4 right-4 flex items-start justify-between z-20 pointer-events-none gap-4">
         <div className="bg-slate-900/80 border border-slate-700/60 rounded-lg px-3 py-1.5 text-xs text-slate-300">
           {lessonLabel} · {lessonTitle}
         </div>
-        <div
-          className={`rounded-lg px-3 py-1.5 text-xs border ${
-            connectionState === 'connected'
-              ? 'bg-emerald-900/70 text-emerald-200 border-emerald-700/80'
-              : connectionState === 'disconnected'
-              ? 'bg-red-900/70 text-red-200 border-red-700/80'
-              : 'bg-amber-900/70 text-amber-200 border-amber-700/80'
-          }`}
-        >
-          {getConnectionLabel(connectionState)}
-        </div>
+        {statusBadge && (
+          <div
+            className={`rounded-lg px-3 py-1.5 text-xs border ${statusBadge.className}`}
+          >
+            {statusBadge.label}
+          </div>
+        )}
       </div>
 
       <div className="min-h-screen flex items-center justify-center p-6 md:p-10">
@@ -79,7 +105,7 @@ export default function AudienceView({
             <p className="text-slate-300 mt-2">
               {connectionState === 'missing-session'
                 ? 'No active session was provided.'
-                : 'Your browser does not support cross-window sync for this mode.'}
+                : 'Presenter sync is unavailable for the current mode.'}
             </p>
           </div>
         )}
@@ -131,7 +157,7 @@ export default function AudienceView({
         <div className="fixed bottom-6 left-0 right-0 flex items-center justify-center gap-4 z-20">
           <button
             onClick={onPrev}
-            disabled={currentSlide <= 0}
+            disabled={!controlsEnabled || currentSlide <= 0}
             className="px-5 py-2.5 rounded-lg text-sm font-medium transition-all
               bg-slate-800/80 border border-slate-600/60 text-slate-200
               hover:bg-slate-700/80 hover:border-slate-500
@@ -144,7 +170,7 @@ export default function AudienceView({
           </span>
           <button
             onClick={onNext}
-            disabled={currentSlide >= totalSlides - 1}
+            disabled={!controlsEnabled || currentSlide >= totalSlides - 1}
             className="px-5 py-2.5 rounded-lg text-sm font-medium transition-all
               bg-slate-800/80 border border-slate-600/60 text-slate-200
               hover:bg-slate-700/80 hover:border-slate-500

--- a/src/hooks/usePresentationChannel.ts
+++ b/src/hooks/usePresentationChannel.ts
@@ -1,72 +1,229 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import {
   buildPresentationChannelName,
+  isFreshPresentationMessage,
   isPresentationSyncMessage,
+  type PresentationSenderRole,
   type PresentationSyncMessage,
 } from '../types/presentation'
+import {
+  buildCloudflareWebSocketUrl,
+  getPresentationSyncCapability,
+  parsePresentationSyncConfig,
+  resolvePresentationTransport,
+  shouldUseBroadcastFallback,
+  type PresentationSyncCapability,
+  type PresentationTransportKind,
+  type PresentationTransportStatus,
+} from '../types/presentationTransport'
 
-type TransportStatus = 'idle' | 'unsupported' | 'ready'
+type TransportSender = (message: PresentationSyncMessage) => boolean
 
 interface UsePresentationChannelResult {
   latestMessage: PresentationSyncMessage | null
-  transportStatus: TransportStatus
+  transportStatus: PresentationTransportStatus
+  transportKind: PresentationTransportKind | null
+  syncCapability: PresentationSyncCapability
   sendMessage: (message: PresentationSyncMessage) => boolean
 }
 
-export function usePresentationChannel(sessionId: string | null): UsePresentationChannelResult {
+interface UsePresentationChannelOptions {
+  senderRole: PresentationSenderRole
+  controlToken?: string | null
+}
+
+export function usePresentationChannel(
+  sessionId: string | null,
+  options: UsePresentationChannelOptions,
+): UsePresentationChannelResult {
+  const syncConfig = useMemo(() => parsePresentationSyncConfig(import.meta.env), [])
   const [latestMessage, setLatestMessage] = useState<PresentationSyncMessage | null>(null)
-  const [transportStatus, setTransportStatus] = useState<TransportStatus>('idle')
+  const [transportStatus, setTransportStatus] = useState<PresentationTransportStatus>('idle')
+  const [transportKind, setTransportKind] = useState<PresentationTransportKind | null>(null)
   const channelRef = useRef<BroadcastChannel | null>(null)
+  const socketRef = useRef<WebSocket | null>(null)
+  const senderRef = useRef<TransportSender | null>(null)
+
+  const cleanupTransport = useCallback(() => {
+    channelRef.current?.close()
+    channelRef.current = null
+
+    if (socketRef.current) {
+      const socket = socketRef.current
+      if (socket.readyState === WebSocket.CONNECTING || socket.readyState === WebSocket.OPEN) {
+        socket.close()
+      }
+    }
+    socketRef.current = null
+    senderRef.current = null
+  }, [])
 
   useEffect(() => {
+    let disposed = false
+    let didFallback = false
+
+    cleanupTransport()
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setLatestMessage(null)
+
     if (!sessionId) {
-      channelRef.current?.close()
-      channelRef.current = null
-      // eslint-disable-next-line react-hooks/set-state-in-effect
       setTransportStatus('idle')
+      setTransportKind(null)
       return
     }
 
-    if (typeof window === 'undefined' || !('BroadcastChannel' in window)) {
-      channelRef.current?.close()
-      channelRef.current = null
-      setTransportStatus('unsupported')
-      return
+    const attachBroadcastTransport = (status: PresentationTransportStatus) => {
+      if (typeof window === 'undefined' || !('BroadcastChannel' in window)) {
+        setTransportKind(null)
+        setTransportStatus('unsupported')
+        return
+      }
+
+      const channel = new BroadcastChannel(buildPresentationChannelName(sessionId))
+      channelRef.current = channel
+      senderRef.current = (message) => {
+        channel.postMessage(message)
+        return true
+      }
+      setTransportKind('broadcast')
+      setTransportStatus(status)
+
+      channel.onmessage = (event: MessageEvent<unknown>) => {
+          if (!isPresentationSyncMessage(event.data) || event.data.sessionId !== sessionId || !isFreshPresentationMessage(event.data)) {
+            return
+          }
+
+        setLatestMessage(event.data)
+      }
     }
 
-    const channel = new BroadcastChannel(buildPresentationChannelName(sessionId))
-    channelRef.current = channel
-    setTransportStatus('ready')
+    const fallbackToBroadcast = () => {
+      if (didFallback || !shouldUseBroadcastFallback(syncConfig.mode)) {
+        return
+      }
+      didFallback = true
+      cleanupTransport()
+      attachBroadcastTransport('fallback')
+    }
 
-    channel.onmessage = (event: MessageEvent<unknown>) => {
-      if (!isPresentationSyncMessage(event.data)) {
+    const connectCloudflareTransport = () => {
+      if (typeof window === 'undefined' || typeof window.WebSocket === 'undefined') {
+        if (shouldUseBroadcastFallback(syncConfig.mode)) {
+          fallbackToBroadcast()
+          return
+        }
+        setTransportKind(null)
+        setTransportStatus('unsupported')
         return
       }
 
-      if (event.data.sessionId !== sessionId) {
+      if (!syncConfig.cloudflareUrl) {
+        if (shouldUseBroadcastFallback(syncConfig.mode)) {
+          fallbackToBroadcast()
+          return
+        }
+        setTransportKind(null)
+        setTransportStatus('error')
         return
       }
 
-      setLatestMessage(event.data)
+      const socketUrl = buildCloudflareWebSocketUrl(syncConfig.cloudflareUrl, sessionId, options.senderRole, options.controlToken)
+      if (!socketUrl) {
+        if (shouldUseBroadcastFallback(syncConfig.mode)) {
+          fallbackToBroadcast()
+          return
+        }
+        setTransportKind(null)
+        setTransportStatus('error')
+        return
+      }
+
+      const socket = new WebSocket(socketUrl)
+      socketRef.current = socket
+      senderRef.current = (message) => {
+        if (socket.readyState !== WebSocket.OPEN) {
+          return false
+        }
+
+        socket.send(JSON.stringify(message))
+        return true
+      }
+      setTransportKind('cloudflare')
+      setTransportStatus('connecting')
+
+      const failCloudflareTransport = () => {
+        if (disposed) {
+          return
+        }
+
+        if (shouldUseBroadcastFallback(syncConfig.mode)) {
+          fallbackToBroadcast()
+          return
+        }
+
+        cleanupTransport()
+        setTransportKind(null)
+        setTransportStatus('error')
+      }
+
+      socket.onopen = () => {
+        if (disposed) {
+          socket.close()
+          return
+        }
+        setTransportStatus('ready')
+      }
+
+      socket.onmessage = (event) => {
+        if (typeof event.data !== 'string') {
+          return
+        }
+
+        try {
+          const payload: unknown = JSON.parse(event.data)
+          if (!isPresentationSyncMessage(payload) || payload.sessionId !== sessionId || !isFreshPresentationMessage(payload)) {
+            return
+          }
+
+          setLatestMessage(payload)
+        } catch {
+          // Ignore invalid payloads from the relay.
+        }
+      }
+
+      socket.onerror = () => {
+        // Wait for onclose to finalize fallback/error state.
+      }
+
+      socket.onclose = () => {
+        failCloudflareTransport()
+      }
+    }
+
+    if (resolvePresentationTransport(syncConfig) === 'cloudflare') {
+      connectCloudflareTransport()
+    } else {
+      attachBroadcastTransport('ready')
     }
 
     return () => {
-      channel.close()
-      channelRef.current = null
+      disposed = true
+      cleanupTransport()
     }
-  }, [sessionId])
+  }, [cleanupTransport, options.controlToken, options.senderRole, sessionId, syncConfig])
 
   const sendMessage = useCallback((message: PresentationSyncMessage): boolean => {
-    if (!channelRef.current) {
+    if (!senderRef.current) {
       return false
     }
-    channelRef.current.postMessage(message)
-    return true
+    return senderRef.current(message)
   }, [])
 
   return {
     latestMessage,
     transportStatus,
+    transportKind,
+    syncCapability: getPresentationSyncCapability(transportKind, transportStatus),
     sendMessage,
   }
 }

--- a/src/types/presentation.test.ts
+++ b/src/types/presentation.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canAudienceControlPresenter,
+  createPresentationMessage,
+  isFreshPresentationMessage,
+  isAllowedPresentationMessageForSender,
+  isPresenterBroadcastMessage,
+  isPresentationSyncMessage,
+  parseControlToken,
+  parseSessionId,
+  parseViewMode,
+  shouldAcceptAudienceControlMessage,
+} from './presentation'
+import {
+  buildCloudflareWebSocketUrl,
+  getPresentationSyncCapability,
+  getPresentationSyncCapabilityLabel,
+  isPresentationTransportActive,
+  parsePresentationSyncConfig,
+  resolvePresentationTransport,
+} from './presentationTransport'
+
+describe('presentation helpers', () => {
+  it('parses view, session, and control token from the URL query', () => {
+    expect(parseViewMode('?view=presenter')).toBe('presenter')
+    expect(parseViewMode('?view=audience')).toBe('audience')
+    expect(parseViewMode('?view=unknown')).toBe('single')
+
+    expect(parseSessionId('?session=demo-session')).toBe('demo-session')
+    expect(parseSessionId('?session=   ')).toBeNull()
+
+    expect(parseControlToken('?control=demo-control')).toBe('demo-control')
+    expect(parseControlToken('?control=   ')).toBeNull()
+  })
+
+  it('only enables audience control when audience mode has both session and control token', () => {
+    expect(canAudienceControlPresenter('audience', 'demo-session', 'demo-control')).toBe(true)
+    expect(canAudienceControlPresenter('audience', 'demo-session', null)).toBe(false)
+    expect(canAudienceControlPresenter('presenter', 'demo-session', 'demo-control')).toBe(false)
+    expect(canAudienceControlPresenter('single', null, null)).toBe(false)
+  })
+
+  it('creates valid presenter and audience sync messages', () => {
+    const presenterMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 2, 'presenter')
+    const audienceMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 2, 'audience', {
+      controlToken: 'demo-control',
+    })
+
+    expect(isPresentationSyncMessage(presenterMessage)).toBe(true)
+    expect(isPresentationSyncMessage(audienceMessage)).toBe(true)
+    expect(audienceMessage.controlToken).toBe('demo-control')
+  })
+
+  it('only accepts audience control messages with the active control token', () => {
+    const validAudienceMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 3, 'audience', {
+      controlToken: 'demo-control',
+    })
+    const wrongTokenMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 3, 'audience', {
+      controlToken: 'wrong-control',
+    })
+    const presenterMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 3, 'presenter')
+
+    expect(shouldAcceptAudienceControlMessage(validAudienceMessage, 'demo-control')).toBe(true)
+    expect(shouldAcceptAudienceControlMessage(wrongTokenMessage, 'demo-control')).toBe(false)
+    expect(shouldAcceptAudienceControlMessage(presenterMessage, 'demo-control')).toBe(false)
+    expect(shouldAcceptAudienceControlMessage(validAudienceMessage, null)).toBe(false)
+  })
+
+  it('rejects message types that do not match the sender role', () => {
+    const invalidAudienceHeartbeat = createPresentationMessage('HEARTBEAT', 'demo-session', 'lesson1-morning', 0, 'audience')
+    const invalidAudienceEndSession = createPresentationMessage('END_SESSION', 'demo-session', 'lesson1-morning', 0, 'audience')
+    const invalidPresenterRequestSync = createPresentationMessage('REQUEST_SYNC', 'demo-session', 'lesson1-morning', 0, 'presenter')
+    const validPresenterHeartbeat = createPresentationMessage('HEARTBEAT', 'demo-session', 'lesson1-morning', 0, 'presenter')
+
+    expect(isAllowedPresentationMessageForSender(validPresenterHeartbeat)).toBe(true)
+    expect(isAllowedPresentationMessageForSender(invalidAudienceHeartbeat)).toBe(false)
+    expect(isAllowedPresentationMessageForSender(invalidAudienceEndSession)).toBe(false)
+    expect(isAllowedPresentationMessageForSender(invalidPresenterRequestSync)).toBe(false)
+    expect(isPresentationSyncMessage(invalidAudienceHeartbeat)).toBe(false)
+    expect(isPresenterBroadcastMessage(validPresenterHeartbeat)).toBe(true)
+    expect(isPresenterBroadcastMessage(invalidAudienceHeartbeat)).toBe(false)
+  })
+
+  it('accepts only fresh messages within the allowed replay window', () => {
+    const freshMessage = createPresentationMessage('SYNC_STATE', 'demo-session', 'lesson1-morning', 0, 'presenter')
+    const staleMessage = {
+      ...freshMessage,
+      sentAt: freshMessage.sentAt - 31_000,
+    }
+    const futureMessage = {
+      ...freshMessage,
+      sentAt: freshMessage.sentAt + 11_000,
+    }
+
+    expect(isFreshPresentationMessage(freshMessage, freshMessage.sentAt + 5_000)).toBe(true)
+    expect(isFreshPresentationMessage(staleMessage, freshMessage.sentAt)).toBe(false)
+    expect(isFreshPresentationMessage(futureMessage, freshMessage.sentAt)).toBe(false)
+  })
+
+  it('parses sync transport config and selects the expected transport', () => {
+    expect(parsePresentationSyncConfig({})).toEqual({
+      mode: 'auto',
+      cloudflareUrl: null,
+    })
+
+    expect(parsePresentationSyncConfig({
+      VITE_PRESENTATION_SYNC_MODE: 'cloudflare',
+      VITE_PRESENTATION_SYNC_URL: ' https://sync.example.com/websocket ',
+    })).toEqual({
+      mode: 'cloudflare',
+      cloudflareUrl: 'https://sync.example.com/websocket',
+    })
+
+    expect(resolvePresentationTransport({
+      mode: 'auto',
+      cloudflareUrl: null,
+    })).toBe('broadcast')
+
+    expect(resolvePresentationTransport({
+      mode: 'auto',
+      cloudflareUrl: 'https://sync.example.com/websocket',
+    })).toBe('cloudflare')
+  })
+
+  it('builds websocket URLs and reports sync capability labels', () => {
+    expect(buildCloudflareWebSocketUrl('https://sync.example.com/websocket', 'demo-session', 'presenter'))
+      .toBe('wss://sync.example.com/websocket?session=demo-session&role=presenter')
+    expect(buildCloudflareWebSocketUrl('http://localhost:8787/websocket', 'demo-session', 'audience', 'demo-control'))
+      .toBe('ws://localhost:8787/websocket?session=demo-session&role=audience&control=demo-control')
+    expect(buildCloudflareWebSocketUrl('ftp://invalid.example.com', 'demo-session', 'presenter')).toBeNull()
+
+    expect(isPresentationTransportActive('ready')).toBe(true)
+    expect(isPresentationTransportActive('fallback')).toBe(true)
+    expect(isPresentationTransportActive('connecting')).toBe(false)
+
+    expect(getPresentationSyncCapability('cloudflare', 'ready')).toBe('cross-browser')
+    expect(getPresentationSyncCapability('broadcast', 'fallback')).toBe('same-browser')
+    expect(getPresentationSyncCapability(null, 'unsupported')).toBe('unavailable')
+
+    expect(getPresentationSyncCapabilityLabel('cross-browser')).toBe('Cross-browser sync')
+    expect(getPresentationSyncCapabilityLabel('same-browser')).toBe('Same-browser only')
+  })
+})

--- a/src/types/presentation.ts
+++ b/src/types/presentation.ts
@@ -1,4 +1,7 @@
 export type ViewMode = 'presenter' | 'audience' | 'single'
+export type PresentationSenderRole = 'presenter' | 'audience'
+export const MAX_PRESENTATION_MESSAGE_AGE_MS = 30_000
+export const MAX_PRESENTATION_MESSAGE_FUTURE_SKEW_MS = 10_000
 
 export type PresentationMessageType = 'SYNC_STATE' | 'REQUEST_SYNC' | 'HEARTBEAT' | 'END_SESSION'
 
@@ -7,13 +10,22 @@ export interface PresentationSyncMessage {
   sessionId: string
   lessonId: string
   slideIndex: number
+  senderRole: PresentationSenderRole
+  controlToken?: string
   sentAt: number
 }
 
 const messageTypes: PresentationMessageType[] = ['SYNC_STATE', 'REQUEST_SYNC', 'HEARTBEAT', 'END_SESSION']
+const senderRoles: PresentationSenderRole[] = ['presenter', 'audience']
+const presenterMessageTypes: PresentationMessageType[] = ['SYNC_STATE', 'HEARTBEAT', 'END_SESSION']
+const audienceMessageTypes: PresentationMessageType[] = ['SYNC_STATE', 'REQUEST_SYNC']
 
 function isPresentationMessageType(value: unknown): value is PresentationMessageType {
   return typeof value === 'string' && messageTypes.includes(value as PresentationMessageType)
+}
+
+function isPresentationSenderRole(value: unknown): value is PresentationSenderRole {
+  return typeof value === 'string' && senderRoles.includes(value as PresentationSenderRole)
 }
 
 export function parseViewMode(search: string): ViewMode {
@@ -34,6 +46,16 @@ export function parseSessionId(search: string): string | null {
   return sessionId.length > 0 ? sessionId : null
 }
 
+export function parseControlToken(search: string): string | null {
+  const raw = new URLSearchParams(search).get('control')
+  if (!raw) {
+    return null
+  }
+
+  const controlToken = raw.trim()
+  return controlToken.length > 0 ? controlToken : null
+}
+
 export function buildPresentationChannelName(sessionId: string): string {
   return `k8s-course-presenter:${sessionId}`
 }
@@ -43,14 +65,60 @@ export function createPresentationMessage(
   sessionId: string,
   lessonId: string,
   slideIndex: number,
+  senderRole: PresentationSenderRole,
+  options?: { controlToken?: string | null },
 ): PresentationSyncMessage {
-  return {
+  const message: PresentationSyncMessage = {
     type,
     sessionId,
     lessonId,
     slideIndex,
+    senderRole,
     sentAt: Date.now(),
   }
+
+  if (options?.controlToken) {
+    message.controlToken = options.controlToken
+  }
+
+  return message
+}
+
+export function canAudienceControlPresenter(
+  viewMode: ViewMode,
+  sessionId: string | null,
+  controlToken: string | null,
+): boolean {
+  return viewMode === 'audience' && Boolean(sessionId) && Boolean(controlToken)
+}
+
+export function shouldAcceptAudienceControlMessage(
+  message: PresentationSyncMessage,
+  activeControlToken: string | null,
+): boolean {
+  return (
+    message.type === 'SYNC_STATE' &&
+    message.senderRole === 'audience' &&
+    Boolean(activeControlToken) &&
+    message.controlToken === activeControlToken
+  )
+}
+
+export function isAllowedPresentationMessageForSender(message: PresentationSyncMessage): boolean {
+  if (message.senderRole === 'presenter') {
+    return presenterMessageTypes.includes(message.type)
+  }
+
+  return audienceMessageTypes.includes(message.type)
+}
+
+export function isPresenterBroadcastMessage(message: PresentationSyncMessage): boolean {
+  return message.senderRole === 'presenter' && presenterMessageTypes.includes(message.type)
+}
+
+export function isFreshPresentationMessage(message: PresentationSyncMessage, now = Date.now()): boolean {
+  const messageAge = now - message.sentAt
+  return messageAge >= -MAX_PRESENTATION_MESSAGE_FUTURE_SKEW_MS && messageAge <= MAX_PRESENTATION_MESSAGE_AGE_MS
 }
 
 export function isPresentationSyncMessage(value: unknown): value is PresentationSyncMessage {
@@ -59,7 +127,7 @@ export function isPresentationSyncMessage(value: unknown): value is Presentation
   }
 
   const record = value as Record<string, unknown>
-  return (
+  const isStructurallyValid = (
     isPresentationMessageType(record.type) &&
     typeof record.sessionId === 'string' &&
     record.sessionId.length > 0 &&
@@ -68,7 +136,15 @@ export function isPresentationSyncMessage(value: unknown): value is Presentation
     typeof record.slideIndex === 'number' &&
     Number.isInteger(record.slideIndex) &&
     record.slideIndex >= 0 &&
+    isPresentationSenderRole(record.senderRole) &&
+    (record.controlToken === undefined || (typeof record.controlToken === 'string' && record.controlToken.length > 0)) &&
     typeof record.sentAt === 'number' &&
     Number.isFinite(record.sentAt)
   )
+
+  if (!isStructurallyValid) {
+    return false
+  }
+
+  return isAllowedPresentationMessageForSender(record as unknown as PresentationSyncMessage)
 }

--- a/src/types/presentationTransport.ts
+++ b/src/types/presentationTransport.ts
@@ -1,0 +1,105 @@
+import type { PresentationSenderRole } from './presentation'
+
+export type PresentationSyncMode = 'auto' | 'broadcast' | 'cloudflare'
+export type PresentationTransportKind = 'broadcast' | 'cloudflare'
+export type PresentationTransportStatus = 'idle' | 'connecting' | 'ready' | 'fallback' | 'unsupported' | 'error'
+export type PresentationSyncCapability = 'cross-browser' | 'same-browser' | 'unavailable'
+
+export interface PresentationSyncConfig {
+  mode: PresentationSyncMode
+  cloudflareUrl: string | null
+}
+
+export function parsePresentationSyncMode(value: string | null | undefined): PresentationSyncMode {
+  if (value === 'broadcast' || value === 'cloudflare') {
+    return value
+  }
+
+  return 'auto'
+}
+
+export function parsePresentationSyncConfig(env: Record<string, string | boolean | undefined>): PresentationSyncConfig {
+  const rawUrl = env.VITE_PRESENTATION_SYNC_URL
+  const normalizedUrl = typeof rawUrl === 'string' ? rawUrl.trim() : ''
+
+  return {
+    mode: parsePresentationSyncMode(typeof env.VITE_PRESENTATION_SYNC_MODE === 'string' ? env.VITE_PRESENTATION_SYNC_MODE : undefined),
+    cloudflareUrl: normalizedUrl.length > 0 ? normalizedUrl : null,
+  }
+}
+
+export function resolvePresentationTransport(config: PresentationSyncConfig): PresentationTransportKind {
+  if (config.mode === 'broadcast') {
+    return 'broadcast'
+  }
+
+  if (config.mode === 'cloudflare') {
+    return 'cloudflare'
+  }
+
+  return config.cloudflareUrl ? 'cloudflare' : 'broadcast'
+}
+
+export function shouldUseBroadcastFallback(mode: PresentationSyncMode): boolean {
+  return mode === 'auto'
+}
+
+export function buildCloudflareWebSocketUrl(
+  baseUrl: string,
+  sessionId: string,
+  senderRole: PresentationSenderRole,
+  controlToken?: string | null,
+): string | null {
+  try {
+    const url = new URL(baseUrl)
+    if (url.protocol === 'https:') {
+      url.protocol = 'wss:'
+    } else if (url.protocol === 'http:') {
+      url.protocol = 'ws:'
+    } else if (url.protocol !== 'ws:' && url.protocol !== 'wss:') {
+      return null
+    }
+
+    url.searchParams.set('session', sessionId)
+    url.searchParams.set('role', senderRole)
+    if (controlToken) {
+      url.searchParams.set('control', controlToken)
+    } else {
+      url.searchParams.delete('control')
+    }
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
+export function isPresentationTransportActive(status: PresentationTransportStatus): boolean {
+  return status === 'ready' || status === 'fallback'
+}
+
+export function getPresentationSyncCapability(
+  transportKind: PresentationTransportKind | null,
+  transportStatus: PresentationTransportStatus,
+): PresentationSyncCapability {
+  if (!transportKind) {
+    return 'unavailable'
+  }
+
+  if (transportStatus === 'idle' || transportStatus === 'unsupported' || transportStatus === 'error') {
+    return 'unavailable'
+  }
+
+  return transportKind === 'cloudflare' ? 'cross-browser' : 'same-browser'
+}
+
+export function getPresentationSyncCapabilityLabel(capability: PresentationSyncCapability): string {
+  if (capability === 'cross-browser') {
+    return 'Cross-browser sync'
+  }
+
+  if (capability === 'same-browser') {
+    return 'Same-browser only'
+  }
+
+  return 'Sync unavailable'
+}


### PR DESCRIPTION
## Summary
This PR adds an optional Cloudflare Workers + Durable Objects realtime transport for presenter sync while preserving the existing GitHub Pages default behavior. Without any extra deployment, the site still works with same-browser presenter sync through `BroadcastChannel`. When a Cloudflare relay URL is configured, presenter and audience can sync across different browsers and devices.

## User impact
Before this change, presenter sync only worked inside the same browser/profile because the app relied on `BroadcastChannel`. Sharing an audience link to another browser resulted in a disconnected audience experience even though the presenter flow itself looked healthy. That made the presenter mode fragile for real course delivery when the presenter wanted a second browser, a different profile, or another device.

With this change, the presenter flow now supports an optional cross-browser path. The presenter can keep using the popup controller audience window as before, and when cross-browser sync is active the toolbar also exposes a read-only audience URL that can be copied to other browsers. If the realtime endpoint is missing or unavailable, the app degrades cleanly back to same-browser sync instead of breaking presenter mode.

## Root cause
The existing transport layer was implemented as a local browser channel only. The project was deployed as a static GitHub Pages site with no relay service, so there was no networked transport that could bridge tabs from different browsers or devices. The original message validation was also light, which was acceptable for same-browser demos but weak once a network relay was introduced.

## Fix
The frontend transport layer has been refactored to support transport selection. It can now use an optional Cloudflare WebSocket relay or fall back to `BroadcastChannel` in `auto` mode. Presenter and audience UI now distinguish cross-browser sync from same-browser fallback without cluttering the audience screen during normal use.

This PR also adds a self-contained Cloudflare module under `cloudflare/presenter-sync/` so the realtime feature is optional and does not become a mandatory dependency for the open source project. The worker uses Durable Objects to manage one room per session and replays the latest presenter state to new audience connections.

On the security side, the message contract is stricter: sender roles are validated, stale messages are ignored, read-only audience connections cannot send controller sync events, oversized payloads are rejected, and the worker can enforce an origin allowlist plus a room connection cap. The copied audience URL is intentionally read-only and never includes the presenter control token.

The docs were updated to explain rollout order, GitHub Pages build-time variables, Cloudflare deployment, security expectations, and manual verification steps.

## Validation
I validated the change set with:

- `npm run test`
- `npx eslint src/App.tsx src/hooks/usePresentationChannel.ts src/types/presentation.ts src/types/presentation.test.ts src/types/presentationTransport.ts cloudflare/presenter-sync/src/index.ts cloudflare/presenter-sync/src/presentationRoom.ts cloudflare/presenter-sync/src/presentationRoom.test.ts`
- `npm run build`

I also verified the fallback behavior in the browser: without Cloudflare configuration, presenter mode stays functional and clearly reports same-browser sync rather than pretending cross-browser sync is available.
